### PR TITLE
Change from learning.cisco.com to developer.cisco.com/learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These self-paced interactive tutorials provide instructions for developers to learn how to use XAPIs.
 
-We write these labs for display within the [Cisco DevNet Learning Labs system](https://learninglabs.cisco.com).
+We write these labs for display within the [Cisco DevNet Learning Labs system](https://developer.cisco.com/learning).
 
 Contributions are welcome, and we are glad to review changes through pull requests. See [contributing.md](contributing.md) for details.
 

--- a/contributing.md
+++ b/contributing.md
@@ -16,7 +16,7 @@ For public repo Learning Labs, use the issue tracker in the repo. All Learning L
 
 For private Learning Labs, use the common issue tracker in the [CiscoDevNet/learning-labs-issues](https://github.com/CiscoDevNet/learning-labs-issues) repo.
 
-For DevNet Express events, use these three issue tracker repos based on the content track:
+For DevNet Express events, use these issue tracker repos based on the content track:
 
     https://github.com/CiscoDevNet/devnet-express-dna-issues
     https://github.com/CiscoDevNet/devnet-express-cc-issues

--- a/contributing.md
+++ b/contributing.md
@@ -21,6 +21,7 @@ For DevNet Express events, use these three issue tracker repos based on the cont
     https://github.com/CiscoDevNet/devnet-express-dna-issues
     https://github.com/CiscoDevNet/devnet-express-cc-issues
     https://github.com/CiscoDevNet/devnet-express-dci-issues
+    https://github.com/CiscoDevNet/devnet-express-security-issues
 
 Use the issue tracker to suggest additions, report bugs, and ask questions. This is also a great way to connect with the developers of the project and find others interested in this solution.
 
@@ -28,6 +29,6 @@ Also use the issue tracker to find ways to contribute. Test a lab, find a bug, l
 
 ## Changing the Learning Lab content
 
-Generally speaking, you should fork the Learning Lab repository, make changes in your fork, and then submit a Pull Request (PR). We expect you have validated that all documented tasks work as expected. Plus, the content should follow the [Learning Lab Style Guide](https://github.com/CiscoDevNet/devnet-writing-guidelines/wiki/Lab-Style-Guide).
+Generally speaking, you should clone the Learning Lab repository, make changes locally, and then submit a Pull Request (PR). We expect you have validated that all documented tasks work as expected. Plus, the content should follow the [Learning Lab Style Guide](https://github.com/CiscoDevNet/devnet-writing-guidelines/wiki/Lab-Style-Guide).
 
 The [DevNet Writing Guidelines Wiki](https://github.com/CiscoDevNet/devnet-writing-guidelines/wiki) describes the review and publishing process in detail. Please feel free to request reviews from DevNet contributors you see in the repository and we will review submissions.

--- a/labs/collab-xapi-branding/1.md
+++ b/labs/collab-xapi-branding/1.md
@@ -26,7 +26,7 @@ In this lab, you’ll learn to add your own logo and custom message to a Cisco c
   * REST API test client: cross-platform - [Postman](https://www.getpostman.com/)
   * Node.js: v8+ [Node.js](https://nodejs.org/en/)
 
-**Finally, we recommend completing the [Introduction to xAPI](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/1) learning lab, as we will assume here that you are familiar with the standard room device web UI, and xAPI programming.**
+**Finally, we recommend completing the [Introduction to xAPI](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/1) learning lab, as we will assume here that you are familiar with the standard room device web UI, and xAPI programming.**
 
 ## About personalization and corporate branding
 

--- a/labs/collab-xapi-branding/2.md
+++ b/labs/collab-xapi-branding/2.md
@@ -18,7 +18,7 @@ Before we can learn to automate customizing via code, it will be good to underst
 
     ![Brand Logo](assets/images/brand-logo.png)
 
-4. Select an image file for the logo.  You can download a [sample logo file here](https://learninglabs.cisco.com/posts/files/collab-xapi-branding/assets/images/logo-create-translucide.png), or use your own custom PNG image (best results with transparent background and size of 272 x 272 pixels)
+4. Select an image file for the logo.  You can download a [sample logo file here](https://developer.cisco.com/learning/posts/files/collab-xapi-branding/assets/images/logo-create-translucide.png), or use your own custom PNG image (best results with transparent background and size of 272 x 272 pixels)
 
 5. Click **Put the system in Halfwake state** and confirm that your logo is displayed on the screen, as well as your Touch10 (if applicable)
 

--- a/labs/collab-xapi-branding/3.md
+++ b/labs/collab-xapi-branding/3.md
@@ -5,7 +5,7 @@ In this step, we'll perform the same personalizations as before, by sending comm
 **Updating the onscreen 'awake' text message is easy...**
 
 1. On your PC, open a terminal window and create an SSH session to your device.
-For detailed instructions, please refer to [Step 5 of "Introduction to xAPI"](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/5):
+For detailed instructions, please refer to [Step 5 of "Introduction to xAPI"](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/5):
 
     ```Shell
     ssh {room_device_ip} -l {user name}
@@ -29,7 +29,7 @@ xAPI requires that you provide the _complete, actual image data_ when you send t
 
 In fact, that's just what we'll do now...  We’ll first use an online tool (thanks to Browserling.com) where we can upload a test image to be Base64 encoded:
 
-1. Open https://www.browserling.com/tools/image-to-base64 in your web browser, and choose/drag+drop a PNG file into the indicated box, and click **Convert**.  You can use [this sample logo  ](https://learninglabs.cisco.com/posts/files/collab-xapi-branding/assets/images/logo-create-translucide.png) if you like:
+1. Open https://www.browserling.com/tools/image-to-base64 in your web browser, and choose/drag+drop a PNG file into the indicated box, and click **Convert**.  You can use [this sample logo  ](https://developer.cisco.com/learning/posts/files/collab-xapi-branding/assets/images/logo-create-translucide.png) if you like:
 
     ![Convert Image](assets/images/convert-image-service.png)
 

--- a/labs/collab-xapi-branding/4.md
+++ b/labs/collab-xapi-branding/4.md
@@ -2,7 +2,7 @@
 
 In this step, we will experiment with changing branding options using a REST HTTP client.
 
->Note: we will be using [Postman](https://www.getpostman.com) in this lab. If you are new to using Postman with xAPI, take a look at [Step 6 of the "Introduction to xAPI"](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/6) lab to learn how to forge an HTTP request with 'Basic Auth' credentials
+>Note: we will be using [Postman](https://www.getpostman.com) in this lab. If you are new to using Postman with xAPI, take a look at [Step 6 of the "Introduction to xAPI"](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/6) lab to learn how to forge an HTTP request with 'Basic Auth' credentials
 
 **Let’s start by setting a custom message for the device's 'awake' state:**
 

--- a/labs/collab-xapi-branding/5.md
+++ b/labs/collab-xapi-branding/5.md
@@ -2,7 +2,7 @@
 
 In the final step of this lab, you will leverage ‘jsxapi’ – the Node.js JavaScript wrapper for xAPI – in order to customize your device from an external Node.js application.
 
->If you’re new to the [Node.js jsxapi library](https://github.com/cisco-ce/jsxapi), you can learn to run a Node.js script to interact with your device by following [Step 7 of the "Introduction to xAPI" lab](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/7)
+>If you’re new to the [Node.js jsxapi library](https://github.com/cisco-ce/jsxapi), you can learn to run a Node.js script to interact with your device by following [Step 7 of the "Introduction to xAPI" lab](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/7)
 
 1. From a PC terminal, clone the [jsxapi samples project](https://github.com/ObjectIsAdvantag/xapi-samples) from GitHub, and install needed dependencies (including the jsxapi library, and its sub-dependencies):
 

--- a/labs/collab-xapi-controls/1.md
+++ b/labs/collab-xapi-controls/1.md
@@ -20,7 +20,7 @@ Finally, if your device supports JavaScript macros, you will deploy and test the
 
     Alternatively, you can use one of the [RoomKit Sandboxes](https://github.com/CiscoDevNet/awesome-xapi#sandboxes) offered to DevNet community members.
 
-* **We recommend that you complete the [Introduction to xAPI](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/1) learning lab, as we will assume you are familiar with your decice's admin interface and xAPI programming.**
+* **We recommend that you complete the [Introduction to xAPI](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/1) learning lab, as we will assume you are familiar with your decice's admin interface and xAPI programming.**
 
 * If your device is on-premises registered, make sure you are in possession of the 'administrator' credentials.  If cloud-registered, 'administrator' access to the **Control Hub** of the Cisco Webex organization managing your device is required.
 
@@ -30,7 +30,7 @@ Finally, if your device supports JavaScript macros, you will deploy and test the
   - [Google Chrome](https://www.google.com/chrome/) web browser
   - (Recommended)  A Javascript integrated development environment (IDE) is highly desirable to help you run the "Going Further" exercises, and to make troubleshooting runtime issues easier.  E.g. [Visual Studio Code](https://code.visualstudio.com/)
 
-  >Note: check the [Setting up your Javascript IDE](https://learninglabs.cisco.com/tracks/devnet-express-cloud-collab-soft-dev/verify-setup-sd/collab-tools-ide-vscode-sd/step/1) learning lab for detailed guidance on installing Visual Studio Code on your laptop.
+  >Note: check the [Setting up your Javascript IDE](https://developer.cisco.com/learning/tracks/devnet-express-cloud-collab-soft-dev/verify-setup-sd/collab-tools-ide-vscode-sd/step/1) learning lab for detailed guidance on installing Visual Studio Code on your laptop.
 
 ## Step 1: Introduction to In-Room Controls
 

--- a/labs/collab-xapi-controls/4.md
+++ b/labs/collab-xapi-controls/4.md
@@ -2,7 +2,7 @@
 
 In this step, you'll learn to interact with the in-room controls created earlier, via code.
 
-For that purpose, we will create a Node.js script that runs on your local PC, leveraging the jsxapi library - the Node.js/JavaScript wrapper for xAPI - as detailed in Step 7 of the [Introduction to xAPI and Cisco CE Software Customization](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/7) learning lab.
+For that purpose, we will create a Node.js script that runs on your local PC, leveraging the jsxapi library - the Node.js/JavaScript wrapper for xAPI - as detailed in Step 7 of the [Introduction to xAPI and Cisco CE Software Customization](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/7) learning lab.
 
 1. On your PC, open a terminal window, and enter the commands below to create a new folder and install the `jsxapi` library/dependencies:
 

--- a/labs/collab-xapi-controls/7.md
+++ b/labs/collab-xapi-controls/7.md
@@ -68,4 +68,4 @@ Let's implement it:
 
     >Note: if your device doesn't have a main screen display or you can't see it, check the web configuration UI under **Setup** > **Personalization** to see a small rendering of what your display looks like, including any custom message
 
-If you are interested in digging further into the details of your device's personalization/branding capabilities, check out the [Personalizing Collaboration Devices from Code](https://learninglabs.cisco.com/lab/collab-xapi-branding/step/1) learning lab.
+If you are interested in digging further into the details of your device's personalization/branding capabilities, check out the [Personalizing Collaboration Devices from Code](https://developer.cisco.com/learning/lab/collab-xapi-branding/step/1) learning lab.

--- a/labs/collab-xapi-controls/8.md
+++ b/labs/collab-xapi-controls/8.md
@@ -44,7 +44,7 @@ Interact once more with your custom ultrasound panel to confirm everything is wo
 
 ## Going Further
 
-There is much more to learn about the possibilities of JavaScript macros!  We definitely recommend you try the [Exploring xAPI Macros for Cisco collaboration devices](https://learninglabs.cisco.com/lab/collab-xapi-macros/step/1) lab if your're interested...
+There is much more to learn about the possibilities of JavaScript macros!  We definitely recommend you try the [Exploring xAPI Macros for Cisco collaboration devices](https://developer.cisco.com/learning/lab/collab-xapi-macros/step/1) lab if your're interested...
 
 
 To inspire you, we’ve assembled a collection of custom in-room control definition files, macros and Node.js example scripts in this [xAPI samples repo](https://github.com/ObjectIsAdvantag/xapi-samples).

--- a/labs/collab-xapi-intro/1.md
+++ b/labs/collab-xapi-intro/1.md
@@ -46,7 +46,7 @@ In January 2017, CE9.2 introduced customizable **in-room controls**. In-room con
 
 In November 2017, CE9.2.1 took the customization possibilities further, with the introduction of **branding** and **halfwake** display features, while also introducing a powerful **macro** engine. Macros provide a JavaScript run-time environment on board the collaboration device itself, where code that can automate or change parts of the video endpoint behavior can run - avoiding the need to deploy a separate application server. Since both the device itself and any connected peripherals can be controlled from the Touch10 or DX series user interface, users get a consistent experience throughout the meeting room.
 
-In-room controls and macros are explored in the [Creating custom in-room controls and xAPI apps](https://learninglabs.cisco.com/lab/collab-xapi-controls/step/1) and [Exploring on-board xAPI Macros for Cisco collaboration devices](https://learninglabs.cisco.com/lab/collab-xapi-macros/step/1) learning labs.
+In-room controls and macros are explored in the [Creating custom in-room controls and xAPI apps](https://developer.cisco.com/learning/lab/collab-xapi-controls/step/1) and [Exploring on-board xAPI Macros for Cisco collaboration devices](https://developer.cisco.com/learning/lab/collab-xapi-macros/step/1) learning labs.
 
 ### Node.js xAPI library for JavaScript: jsxapi
 

--- a/labs/collab-xapi-intro/2.md
+++ b/labs/collab-xapi-intro/2.md
@@ -37,4 +37,4 @@ We’ll now create a new user on the device for use in this lab.  This user will
 
     ![New user](assets/images/step2-integrator-user.png)
 
-2. Click 'Create user', and go straight to [Step 4](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/4) (skip the next page)
+2. Click 'Create user', and go straight to [Step 4](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/4) (skip the next page)

--- a/labs/collab-xapi-intro/3.md
+++ b/labs/collab-xapi-intro/3.md
@@ -1,6 +1,6 @@
 # Step 3: Accessing the Admin Interface for Webex-Registered Devices
 
-**-->If your device is registered to CUCM/VCS on-premise and you've created the 'integrator' user, you can [skip to the next step](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/4)**
+**-->If your device is registered to CUCM/VCS on-premise and you've created the 'integrator' user, you can [skip to the next step](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/4)**
 
 Follow the instructions below if your device is registered to the Cisco Webex cloud platform:
 

--- a/labs/collab-xapi-intro/8.md
+++ b/labs/collab-xapi-intro/8.md
@@ -140,6 +140,6 @@ Hopefully you can take the overview and details from the language/tool specific 
 
 **Postman** users will also be interested in downloading/importing the [Postman collections for xAPI](https://github.com/CiscoDevNet/postman-xapi). These collections provide examples of common device interactions seen in this lab such as 'Standby' and 'Video Calls', as well as additional features like 'Personalization' and 'Room Analytics'.
 
-We suggest you try your hand at some additional labs to learn more about the programmability features of your device, including [Personalizing Collaboration Devices from Code](https://learninglabs.cisco.com/lab/collab-xapi-branding/step/1) and [Creating custom In-Room Controls and Macros](https://learninglabs.cisco.com/lab/collab-xapi-controls/step/1).
+We suggest you try your hand at some additional labs to learn more about the programmability features of your device, including [Personalizing Collaboration Devices from Code](https://developer.cisco.com/learning/lab/collab-xapi-branding/step/1) and [Creating custom In-Room Controls and Macros](https://developer.cisco.com/learning/lab/collab-xapi-controls/step/1).
 
 Plus try out some additional [introductory samples](https://github.com/ObjectIsAdvantag/xapi-samples), and check the [awesome-xapi](https://github.com/CiscoDevNet/awesome-xapi) github repo for extra community contributed code samples, or contribute your own!

--- a/labs/collab-xapi-macros/1.md
+++ b/labs/collab-xapi-macros/1.md
@@ -29,9 +29,9 @@ In this lab you will learn about the use-cases, capabilities and limitations of 
 
 **We recommend that you complete the following labs prior to attempting this one:**
 
-* [Introduction to xAPI for Cisco collaboration devices](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/1)
-* [Customizing collaboration devices from code](https://learninglabs.cisco.com/lab/collab-xapi-branding/step/1)
-* [Creating custom in-room controls for Cisco collaboration devices](https://learninglabs.cisco.com/lab/collab-xapi-controls/step/1)
+* [Introduction to xAPI for Cisco collaboration devices](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/1)
+* [Customizing collaboration devices from code](https://developer.cisco.com/learning/lab/collab-xapi-branding/step/1)
+* [Creating custom in-room controls for Cisco collaboration devices](https://developer.cisco.com/learning/lab/collab-xapi-controls/step/1)
 
 ## Step 1: About CE customization with xAPI
 

--- a/labs/collab-xapi-macros/2.md
+++ b/labs/collab-xapi-macros/2.md
@@ -64,7 +64,7 @@ You’ll find several tabs with useful links:
 
     ![Custom message](assets/images/step2-custom-message.png)
 
->To learn more about xAPI coding with JavaScript and jsxapi, check out the lab [Introduction to xAPI for Cisco collaboration devices](https://learninglabs.cisco.com/lab/collab-xapi-intro/step/1)
+>To learn more about xAPI coding with JavaScript and jsxapi, check out the lab [Introduction to xAPI for Cisco collaboration devices](https://developer.cisco.com/learning/lab/collab-xapi-intro/step/1)
 
 **Congrats! Your macro is up and running!**
 

--- a/labs/collab-xapi-macros/3.md
+++ b/labs/collab-xapi-macros/3.md
@@ -68,7 +68,7 @@ The sample solution we will now deploy to your room device installs a new macro 
 
 The use-case might be environments where multiple collaboration devices are close together, or even in the same room (such as a demo or training lab!)  It may be desireable to provide an easy way for end-users to disable or attenuate the ultrasound features of individual devices to avoid clients continuously trying to pair with multiple devices.
 
->For a detailed exploration of this sample app and in-room controls, see the learning lab [Creating custom in-room controls and xAPI apps](https://learninglabs.cisco.com/lab/collab-xapi-controls/step/1)
+>For a detailed exploration of this sample app and in-room controls, see the learning lab [Creating custom in-room controls and xAPI apps](https://developer.cisco.com/learning/lab/collab-xapi-controls/step/1)
 
 **Let's perform the config restore:**
 


### PR DESCRIPTION
Wait to merge after Labs are back online, to test the new URLs.